### PR TITLE
Clear the timeout if data is received

### DIFF
--- a/lib/ssq.js
+++ b/lib/ssq.js
@@ -39,6 +39,7 @@ function ssq_request(server, port, request,
 
   function receive_data(data) {
     socket.close();
+	clearTimeout(the_timeout);
     decoder(data, callback);
   };
 
@@ -82,7 +83,7 @@ function ssq_request(server, port, request,
     socket.send(request, 0, request.length, port, server, error_handler);
   }
 
-  setTimeout(timeout_handler, timeout);
+  var the_timeout = setTimeout(timeout_handler, timeout);
 }
 
 // Factory to make the methods we are exporting:

--- a/lib/ssq.js
+++ b/lib/ssq.js
@@ -8,7 +8,7 @@
 // Module imports
 var dgram = require('dgram')
   , pack = require('bufferpack')
-  , decoders = require('./decoders.js');
+  , decoders = require('.c/decoders.js');
 
 // Message request formats, straight from the spec
 // Note: A2A_PING has been deprecated, and the GETCHALLENGE has been replaced
@@ -39,7 +39,7 @@ function ssq_request(server, port, request,
 
   function receive_data(data) {
     socket.close();
-	clearTimeout(the_timeout);
+    clearTimeout(the_timeout);
     decoder(data, callback);
   };
 

--- a/lib/ssq.js
+++ b/lib/ssq.js
@@ -8,7 +8,7 @@
 // Module imports
 var dgram = require('dgram')
   , pack = require('bufferpack')
-  , decoders = require('.c/decoders.js');
+  , decoders = require('./decoders.js');
 
 // Message request formats, straight from the spec
 // Note: A2A_PING has been deprecated, and the GETCHALLENGE has been replaced


### PR DESCRIPTION
Tied the timeout to a variable, the_timeout, and cleared the timeout in the recieve_data() function, because the timeout was going off regardless of receiving and response or not. 
An error would occur when the timeout function would try to socket.close() a closed socket.
